### PR TITLE
Refactor dependency management to use exclusions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,39 @@ repositories {
     maven { url 'https://repo.maven.apache.org/maven2' }
 }
 
+ext {
+    slf4jVersion = '2.0.9'
+    commonsIoVersion = '2.13.0'
+    commonsLang3Version = '3.13.0'
+    commonsCodecVersion = '1.16.0'
+    commonsCompressVersion = '1.24.0'
+    log4jVersion = '2.20.0'
+    bouncycastleVersion = '1.76'
+    byteBuddyVersion = '1.14.6'
+    jacksonVersion = '2.15.2'
+    jnaVersion = '5.13.0'
+    checkerQualVersion = '3.33.0'
+}
+
+dependencyManagement {
+    dependencies {
+        dependency "commons-io:commons-io:${commonsIoVersion}"
+        dependency "org.apache.commons:commons-lang3:${commonsLang3Version}"
+        dependency "commons-codec:commons-codec:${commonsCodecVersion}"
+        dependency "org.apache.commons:commons-compress:${commonsCompressVersion}"
+        dependency "org.apache.logging.log4j:log4j-api:${log4jVersion}"
+        dependency "org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}"
+        dependency "org.bouncycastle:bcmail-jdk18on:${bouncycastleVersion}"
+        dependency "org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}"
+        dependency "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
+        dependency "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+        dependency "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+        dependency "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+        dependency "net.java.dev.jna:jna:${jnaVersion}"
+        dependency "org.checkerframework:checker-qual:${checkerQualVersion}"
+    }
+}
+
 dependencies {
     // Apache PDFBox for PDF processing
     implementation 'org.apache.pdfbox:pdfbox:2.0.29'
@@ -31,11 +64,17 @@ dependencies {
     implementation 'org.apache.poi:poi-scratchpad:5.2.4'
     
     // Apache Tika for document detection
-    implementation 'org.apache.tika:tika-core:2.9.0'
-    implementation 'org.apache.tika:tika-parsers-standard-package:2.9.0'
+    implementation('org.apache.tika:tika-core:2.9.0') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    implementation('org.apache.tika:tika-parsers-standard-package:2.9.0') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     
     // Tesseract for OCR
-    implementation 'net.sourceforge.tess4j:tess4j:5.8.0'
+    implementation('net.sourceforge.tess4j:tess4j:5.8.0') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     
     // Apache Commons for text similarity algorithms
     implementation 'org.apache.commons:commons-text:1.10.0'
@@ -58,12 +97,16 @@ dependencies {
     implementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.1.jre11'
     
     // Connection pooling
-    implementation 'com.zaxxer:HikariCP:5.0.1'
+    implementation('com.zaxxer:HikariCP:5.0.1') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     
     // Logging
     implementation 'org.slf4j:slf4j-api:2.0.9'
     implementation 'org.slf4j:slf4j-simple:2.0.9'
-    implementation 'ch.qos.logback:logback-classic:1.4.11'
+    implementation('ch.qos.logback:logback-classic:1.4.11') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     implementation 'ch.qos.logback:logback-core:1.4.11'
     
     // Monitoring and metrics
@@ -78,8 +121,12 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.h2database:h2:2.2.220'
-    testImplementation 'org.testcontainers:testcontainers:1.19.0'
-    testImplementation 'org.testcontainers:postgresql:1.19.0'
+    testImplementation('org.testcontainers:testcontainers:1.19.0') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    testImplementation('org.testcontainers:postgresql:1.19.0') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 }
 
 // Main class configuration


### PR DESCRIPTION
This commit refactors the `build.gradle` file to use a more fine-grained approach to dependency management.

- Excluded transitive `slf4j-api` dependencies from libraries that bring them in, as the project provides its own SLF4J implementation.
- Kept the `dependencyManagement` block to enforce consistent versions for other common transitive dependencies, ensuring a stable build.

This approach combines the benefits of excluding unnecessary dependencies (making the project lighter) and forcing versions for shared libraries (ensuring stability).