### PR TITLE
Fix(test): Handle .txt files in the test command

### DIFF
--- a/src/main/java/com/loantrading/matching/extraction/MultiFormatDocumentExtractor.java
+++ b/src/main/java/com/loantrading/matching/extraction/MultiFormatDocumentExtractor.java
@@ -44,6 +44,8 @@ public class MultiFormatDocumentExtractor {
                 text = wordExtractor.extractDocxText(documentContent);
             } else if (filename.toLowerCase().endsWith(".doc")) {
                 text = wordExtractor.extractDocText(documentContent);
+            } else if (filename.toLowerCase().endsWith(".txt")) {
+                text = new String(documentContent);
             } else {
                 throw new ExtractionException("Unsupported file format: " + filename);
             }


### PR DESCRIPTION
The "test" command was failing because it was trying to use a .txt file, which was not a supported file format. This change adds support for .txt files in the `MultiFormatDocumentExtractor` by reading the content of the file as a plain string.

This allows the "test" command to run successfully without throwing an `ExtractionException`.